### PR TITLE
Feature/laravel elixir support

### DIFF
--- a/config/twigbridge.php
+++ b/config/twigbridge.php
@@ -110,6 +110,7 @@ return [
             'TwigBridge\Extension\Laravel\Str',
             'TwigBridge\Extension\Laravel\Translator',
             'TwigBridge\Extension\Laravel\Url',
+            'TwigBridge\Extension\Laravel\ElixirExtension',
             // 'TwigBridge\Extension\Laravel\Gate',
 
             // 'TwigBridge\Extension\Laravel\Form',
@@ -209,7 +210,7 @@ return [
         |
         */
         'filters' => [
-            'get' => 'data_get',    
+            'get' => 'data_get',
         ],
-    ],  
+    ],
 ];

--- a/src/Extension/Laravel/ElixirExtension.php
+++ b/src/Extension/Laravel/ElixirExtension.php
@@ -21,7 +21,7 @@ class ElixirExtension extends \Twig_Extension
     protected $manifestName;
     protected $manifest;
 
-    public function __construct($publicDir, $buildDir = 'build', $manifestName = 'rev-manifest.json')
+    public function __construct($publicDir = '../public', $buildDir = 'build', $manifestName = 'rev-manifest.json')
     {
         $this->publicDir = rtrim($publicDir, '/');
         $this->buildDir = trim($buildDir, '/');

--- a/src/Extension/Laravel/ElixirExtension.php
+++ b/src/Extension/Laravel/ElixirExtension.php
@@ -1,0 +1,77 @@
+<?php
+
+/*
+ * (c) Brieuc Thomas <tbrieuc@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace BrieucThomas\Twig\Extension;
+
+/**
+ * Twig extension for the Laravel Elixir component.
+ *
+ * @author Brieuc Thomas <tbrieuc@gmail.com>
+ */
+class ElixirExtension extends \Twig_Extension
+{
+    protected $publicDir;
+    protected $buildDir;
+    protected $manifestName;
+    protected $manifest;
+
+    public function __construct($publicDir, $buildDir = 'build', $manifestName = 'rev-manifest.json')
+    {
+        $this->publicDir = rtrim($publicDir, '/');
+        $this->buildDir = trim($buildDir, '/');
+        $this->manifestName = $manifestName;
+    }
+
+    public function getFunctions()
+    {
+        return [
+            new \Twig_SimpleFunction('elixir', [$this, 'getVersionedFilePath']),
+        ];
+    }
+
+    /**
+     * Gets the public url/path to a versioned Elixir file.
+     *
+     * @param string $file
+     *
+     * @return string
+     *
+     * @throws \InvalidArgumentException
+     */
+    public function getVersionedFilePath($file)
+    {
+        $manifest = $this->getManifest();
+
+        if (!isset($manifest[$file])) {
+            throw new \InvalidArgumentException("File {$file} not defined in asset manifest.");
+        }
+
+        return $this->buildDir.'/'.$manifest[$file];
+    }
+
+    /**
+     * Returns the manifest file content as array.
+     *
+     * @return array
+     */
+    protected function getManifest()
+    {
+        if (null === $this->manifest) {
+            $manifestPath = $this->publicDir.'/'.$this->buildDir.'/'.$this->manifestName;
+            $this->manifest = json_decode(file_get_contents($manifestPath), true);
+        }
+
+        return $this->manifest;
+    }
+
+    public function getName()
+    {
+        return 'elixir';
+    }
+}


### PR DESCRIPTION
Adds Elixir support via an extension to Twig.

Example:
`<link rel="stylesheet" href="{{ elixir("css/good.css") }}">`
`<script type="text/javascript" src="{{ elixir("js/gw.js") }}"></script>`
